### PR TITLE
Added method for adding servlet with specifying name

### DIFF
--- a/apimock-tomcat/src/main/java/me/geso/apimock/APIMockTomcat.java
+++ b/apimock-tomcat/src/main/java/me/geso/apimock/APIMockTomcat.java
@@ -60,6 +60,16 @@ public class APIMockTomcat implements AutoCloseable {
 	 * @throws LifecycleException
 	 */
 	public void start(int port) throws LifecycleException {
+		start(port, "mock");
+	}
+
+	/**
+	 * Start new tomcat server instance with specifying its name.
+	 *
+	 * @param port
+	 * @throws LifecycleException
+	 */
+	public void start(int port, String name) throws LifecycleException {
 		if (this.tomcat != null) {
 			throw new IllegalStateException(
 					"Tomcat is already running.");
@@ -69,8 +79,8 @@ public class APIMockTomcat implements AutoCloseable {
 		tomcat.setPort(port);
 		org.apache.catalina.Context ctx = tomcat.addContext("/",
 			new File(".").getAbsolutePath());
-		Tomcat.addServlet(ctx, "mock", servlet);
-		ctx.addServletMapping("/*", "mock");
+		Tomcat.addServlet(ctx, name, servlet);
+		ctx.addServletMapping("/*", name);
 		tomcat.start();
 	}
 

--- a/apimock-tomcat/src/test/java/me/geso/apimock/APIMockTomcatTest.java
+++ b/apimock-tomcat/src/test/java/me/geso/apimock/APIMockTomcatTest.java
@@ -105,4 +105,16 @@ public class APIMockTomcatTest {
 		}
 	}
 
+	@Test
+	public void testStartWithName() throws Exception {
+		try (APIMockTomcat mock = new APIMockTomcat()){
+			mock.get("/", c -> "OK");
+			mock.start(0, "mock");
+			URI uri = mock.getURI();
+			HttpResponse resp = Request.Get(uri).execute().returnResponse();
+			assertEquals(200, resp.getStatusLine().getStatusCode());
+			assertEquals("\"OK\"", EntityUtils.toString(resp.getEntity()));
+		}
+	}
+
 }


### PR DESCRIPTION
This is a fix for a problem that the following error occurs when we start more than one mocks at the same time.

```
org.apache.catalina.util.LifecycleMBeanBase unregister
WARNING: Failed to unregister MBean with name [Tomcat:j2eeType=Servlet,name=mock,WebModule=//localhost/,J2EEApplication=none,J2EEServer=none] during component destruction
javax.management.InstanceNotFoundException: Tomcat:j2eeType=Servlet,name=mock,WebModule=//localhost/,J2EEApplication=none,J2EEServer=none
    at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getMBean(DefaultMBeanServerInterceptor.java:1095)
    at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.exclusiveUnregisterMBean(DefaultMBeanServerInterceptor.java:427)
    at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.unregisterMBean(DefaultMBeanServerInterceptor.java:415)
    at com.sun.jmx.mbeanserver.JmxMBeanServer.unregisterMBean(JmxMBeanServer.java:546)
    at org.apache.catalina.util.LifecycleMBeanBase.unregister(LifecycleMBeanBase.java:194)
    at org.apache.catalina.util.LifecycleMBeanBase.destroyInternal(LifecycleMBeanBase.java:73)
    at org.apache.catalina.core.ContainerBase.destroyInternal(ContainerBase.java:1247)
    at org.apache.catalina.util.LifecycleBase.destroy(LifecycleBase.java:305)
    at org.apache.catalina.core.ContainerBase.removeChild(ContainerBase.java:1041)
    at org.apache.catalina.core.StandardContext.removeChild(StandardContext.java:4123)
    at org.apache.catalina.core.StandardContext.resetContext(StandardContext.java:5810)
    at org.apache.catalina.core.StandardContext.stopInternal(StandardContext.java:5753)
    at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:232)
    at org.apache.catalina.core.ContainerBase$StopChild.call(ContainerBase.java:1591)
    at org.apache.catalina.core.ContainerBase$StopChild.call(ContainerBase.java:1580)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```

This happens because a servlet is always added with name "mock", 
